### PR TITLE
fix modal

### DIFF
--- a/script.js
+++ b/script.js
@@ -203,18 +203,20 @@ function autoResizeTextarea(textareaId) {
 }
 
 function showDisclaimer() {
-  document.getElementById('disclaimerModal').style.display = 'block';
+  const modal = document.getElementById('disclaimerModal');
+  modal.classList.add('show');
 }
 
 function closeDisclaimer() {
-  document.getElementById('disclaimerModal').style.display = 'none';
+  const modal = document.getElementById('disclaimerModal');
+  modal.classList.remove('show');
 }
 
 // Close modal when clicking outside of it
 window.onclick = function(event) {
   const modal = document.getElementById('disclaimerModal');
   if (event.target === modal) {
-    modal.style.display = 'none';
+    modal.classList.remove('show');
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -219,7 +219,7 @@ footer a:hover {
 
 /* Modal Styles */
 .modal {
-  display: none;
+  display: none !important;
   position: fixed;
   z-index: 1000;
   left: 0;
@@ -227,6 +227,10 @@ footer a:hover {
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.5);
+}
+
+.modal.show {
+  display: block !important;
 }
 
 .modal-content {


### PR DESCRIPTION
## Fix Modal Display Issue

### Summary
Fixed disclaimer modal showing at bottom of page instead of being hidden by default.

### Changes
- Added `!important` to modal CSS to ensure hidden by default
- Updated JavaScript to use CSS classes instead of inline styles
- Added `.modal.show` class for better visibility control
- Removed inline `style="display: none;"` from HTML

### Files Modified
- `index.html` - Removed inline style from modal
- `style.css` - Added `!important` and `.modal.show` class
- `script.js` - Updated modal functions to use classList

### Result
Modal now properly hidden by default and only shows when "Disclaimer" link is clicked.